### PR TITLE
fix slice out of range in local.Command

### DIFF
--- a/runcmd.go
+++ b/runcmd.go
@@ -47,6 +47,9 @@ type Remote struct {
 }
 
 func (this *Local) Command(cmd string) (CmdWorker, error) {
+	if cmd == "" {
+		return nil, errors.New("command cannot be empty")
+	}
 	c := exec.Command(strings.Fields(cmd)[0], strings.Fields(cmd)[1:]...)
 	stdinPipe, err := c.StdinPipe()
 	if err != nil {
@@ -69,6 +72,9 @@ func (this *Local) Command(cmd string) (CmdWorker, error) {
 }
 
 func (this *Remote) Command(cmd string) (CmdWorker, error) {
+	if cmd == "" {
+		return nil, errors.New("command cannot be empty")
+	}
 	s, err := this.serverConn.NewSession()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```
	runner, err := runcmd.NewLocalRunner()
        // some error catch
	command, err := runner.Command("")
       // some error catch
	result, err := command.Run()
	// some error catch
	fmt.Printf("%#v", result)
```
Actual result:
```
panic: runtime error: slice bounds out of range

goroutine 1 [running]:
runtime.panic(0x59a320, 0x7babaa)
	/usr/lib/go/src/pkg/runtime/panic.c:266 +0xb6
github.com/theairkit/runcmd.(*Local).Command(0x7c74c0, 0x5c71a0, 0x0, 0x0, 0x0, ...)
	/home/vx/go/src/github.com/theairkit/runcmd/runcmd.go:50 +0x359
main.main()
```

I think, command cannot be empty, so I fixed this in current pr.