### PR TITLE
error message with command line

### DIFF
--- a/local.go
+++ b/local.go
@@ -8,7 +8,8 @@ import (
 )
 
 type LocalCmd struct {
-	cmd *exec.Cmd
+	cmdline string
+	cmd     *exec.Cmd
 }
 
 type Local struct{}
@@ -17,14 +18,15 @@ func NewLocalRunner() (*Local, error) {
 	return &Local{}, nil
 }
 
-func (runner *Local) Command(cmd string) (CmdWorker, error) {
-	if cmd == "" {
+func (runner *Local) Command(cmdline string) (CmdWorker, error) {
+	if cmdline == "" {
 		return nil, errors.New("command cannot be empty")
 	}
 
-	command := exec.Command(strings.Fields(cmd)[0], strings.Fields(cmd)[1:]...)
+	command := exec.Command(strings.Fields(cmdline)[0], strings.Fields(cmdline)[1:]...)
 	return &LocalCmd{
-		command,
+		cmdline: cmdline,
+		cmd:     command,
 	}, nil
 }
 
@@ -62,4 +64,8 @@ func (cmd *LocalCmd) SetStdout(buffer io.Writer) {
 
 func (cmd *LocalCmd) SetStderr(buffer io.Writer) {
 	cmd.cmd.Stderr = buffer
+}
+
+func (cmd *LocalCmd) GetCommandLine() string {
+	return cmd.cmdline
 }

--- a/remote.go
+++ b/remote.go
@@ -10,7 +10,7 @@ import (
 )
 
 type RemoteCmd struct {
-	cmd     string
+	cmdline string
 	session *ssh.Session
 }
 
@@ -53,8 +53,8 @@ func NewRemotePassAuthRunner(user, host, password string) (*Remote, error) {
 	return &Remote{server}, nil
 }
 
-func (runner *Remote) Command(cmd string) (CmdWorker, error) {
-	if cmd == "" {
+func (runner *Remote) Command(cmdline string) (CmdWorker, error) {
+	if cmdline == "" {
 		return nil, errors.New("command cannot be empty")
 	}
 
@@ -64,7 +64,7 @@ func (runner *Remote) Command(cmd string) (CmdWorker, error) {
 	}
 
 	return &RemoteCmd{
-		cmd:     cmd,
+		cmdline: cmdline,
 		session: session,
 	}, nil
 }
@@ -84,7 +84,7 @@ func (cmd *RemoteCmd) Run() ([]string, error) {
 }
 
 func (cmd *RemoteCmd) Start() error {
-	return cmd.session.Start(cmd.cmd)
+	return cmd.session.Start(cmd.cmdline)
 }
 
 func (cmd *RemoteCmd) Wait() error {
@@ -111,4 +111,8 @@ func (cmd *RemoteCmd) SetStdout(buffer io.Writer) {
 
 func (cmd *RemoteCmd) SetStderr(buffer io.Writer) {
 	cmd.session.Stderr = buffer
+}
+
+func (cmd *RemoteCmd) GetCommandLine() string {
+	return cmd.cmdline
 }


### PR DESCRIPTION
I'm added command line to error messages, it's should be more obvious then just a: 
```
exit status 1:
open /a/b: permission denied
```