### PR TITLE
CmdError method

### DIFF
--- a/local.go
+++ b/local.go
@@ -25,6 +25,11 @@ func (local *Local) Command(name string, arg ...string) CmdWorker {
 	}
 }
 
+// stub to suite interface
+func (local *LocalCmd) CmdError() error {
+	return nil
+}
+
 // Run executes current command and retuns output splitted by newline
 func (cmd *LocalCmd) Run() error {
 	return run(cmd)

--- a/mock.go
+++ b/mock.go
@@ -66,6 +66,10 @@ type MockRunnerWorker struct {
 	}
 }
 
+func (worker *MockRunnerWorker) CmdError() error {
+	return nil
+}
+
 // Run runs Start() and then Wait().
 func (worker *MockRunnerWorker) Run() error {
 	err := worker.Start()

--- a/remote.go
+++ b/remote.go
@@ -279,6 +279,10 @@ func (remote *Remote) CloseConnection() error {
 	return remote.client.Close()
 }
 
+func (remote *RemoteCmd) CmdError() error {
+	return remote.sessionError
+}
+
 // Run executes current command
 func (cmd *RemoteCmd) Run() error {
 	return run(cmd)

--- a/runcmd.go
+++ b/runcmd.go
@@ -33,6 +33,7 @@ type CmdWorker interface {
 	SetStderr(io.Writer)
 	SetStdin(io.Reader)
 	GetArgs() []string
+	CmdError() error
 }
 
 func (err ExecError) Error() string {


### PR DESCRIPTION
added CmdError method to CmdWorker interface, to be able to check if there were errors during ssh session creation.